### PR TITLE
allow symbols(not starting with ?) as constants

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject io.lambdaforge/datalog-parser "0.1.8"
+(defproject io.lambdaforge/datalog-parser "0.1.9"
   :description  "Datalog parser."
   :url          "https://github.com/lambdaforge/datalog-parser"
   :license      {:name "EPL 1.0"

--- a/src/datalog/parser/impl.cljc
+++ b/src/datalog/parser/impl.cljc
@@ -60,7 +60,8 @@
     (RulesVar.)))
 
 (defn parse-constant [form]
-  (when (not (symbol? form))
+  (when-not (and (symbol? form)
+                 (= (first (name form)) \?))
     (datalog.parser.type.Constant. form)))
 
 (defn parse-plain-symbol [form]
@@ -79,8 +80,8 @@
 
 (defn parse-fn-arg [form]
   (or (parse-variable form)
-      (parse-constant form)
-      (parse-src-var  form)))
+      (parse-src-var  form)
+      (parse-constant form)))
 
 ;; rule-vars = [ variable+ | ([ variable+ ] variable*) ]
 

--- a/test/datalog/parser/impl_test.cljc
+++ b/test/datalog/parser/impl_test.cljc
@@ -220,7 +220,13 @@
     (t/->Pattern (t/->SrcVar '$x) [(t/->Placeholder) (t/->Variable '?a) (t/->Placeholder) (t/->Placeholder)])
 
     '[$x _ :name ?v]
-    (t/->Pattern (t/->SrcVar '$x) [(t/->Placeholder) (t/->Constant :name) (t/->Variable '?v)]))
+    (t/->Pattern (t/->SrcVar '$x) [(t/->Placeholder) (t/->Constant :name) (t/->Variable '?v)])
+    
+    '[$x _ sym ?v]
+    (t/->Pattern (t/->SrcVar '$x) [(t/->Placeholder) (t/->Constant 'sym) (t/->Variable '?v)])
+
+    '[$x _ $src-sym ?v]
+    (t/->Pattern (t/->SrcVar '$x) [(t/->Placeholder) (t/->Constant '$src-sym) (t/->Variable '?v)]))
 
   (is (thrown-with-msg? ExceptionInfo #"Pattern could not be empty"
         (dp/parse-clause '[]))))
@@ -259,13 +265,13 @@
     (t/->RuleExpr (t/->DefaultSrc) (t/->PlainSymbol 'friends) [(t/->Constant "Ivan") (t/->Placeholder)])
 
     '($1 friends ?x ?y)
-    (t/->RuleExpr (t/->SrcVar '$1) (t/->PlainSymbol 'friends) [(t/->Variable '?x) (t/->Variable '?y)]))
+    (t/->RuleExpr (t/->SrcVar '$1) (t/->PlainSymbol 'friends) [(t/->Variable '?x) (t/->Variable '?y)])
+    
+    '(friends something)
+    (t/->RuleExpr (t/->DefaultSrc) (t/->PlainSymbol 'friends) [(t/->Constant 'something)]))
 
   (is (thrown-with-msg? ExceptionInfo #"rule-expr requires at least one argument"
-        (dp/parse-clause '(friends))))
-
-  (is (thrown-with-msg? ExceptionInfo #"Cannot parse rule-expr arguments"
-        (dp/parse-clause '(friends something)))))
+        (dp/parse-clause '(friends)))))
 
 (deftest not-clause
   (are [clause res] (= (dp/parse-clause clause) res)


### PR DESCRIPTION
This is a port of: https://github.com/tonsky/datascript/pull/417

This PR allows using symbols(not starting with `?`) as constants in data patterns. This is consistent with Datomic's behaviour.

Notes:

I changed the order of parsers in `parse-fn-arg` otherwise `$x` would parse as a constant, and it shouldn't for function arguments.

I believe the unit test saying `(friends something)` should throw is wrong. I've changed it to a positive test where `something` parses as a constant argument instead.