### PR TITLE
fix: when-let with unused expression

### DIFF
--- a/src/datalog/unparser.cljc
+++ b/src/datalog/unparser.cljc
@@ -100,7 +100,7 @@
   ;; TODO test, check not-join
   Not
   (-unparse [{:keys [source vars clauses]}]
-    (concat (when-let [src (-unparse source)]
+    (concat (if-let [src (-unparse source)]
               (list src 'not)
               (list 'not))
             (map -unparse clauses)))


### PR DESCRIPTION
Fixes #26.

No tests included, since unparsing still needs to be finished and properly tested. 
Issue #6 covers this.