### PR TITLE
refer raise macro in cljs, silence rename warning bug

### DIFF
--- a/src/datalog/parser/impl.cljc
+++ b/src/datalog/parser/impl.cljc
@@ -5,7 +5,7 @@
             [datalog.parser.impl.proto :as p]
             [datalog.parser.impl.util :as util
              #?(:cljs :refer-macros :clj :refer) [raise forv]])
-  (:refer-clojure :rename  {distinct? core-distinct?})
+  (:refer-clojure :rename  {distinct? core-distinct?} #?@(:cljs (:exclude (distinct?))))
   #?(:clj
      (:import [datalog.parser.type
                Not And Or Aggregate SrcVar RulesVar RuleExpr

--- a/src/datalog/parser/impl/util.cljc
+++ b/src/datalog/parser/impl/util.cljc
@@ -1,6 +1,7 @@
 (ns ^:no-doc datalog.parser.impl.util
   (:require [datalog.parser.impl.proto :as proto]
             [clojure.string            :as str])
+  #?(:cljs (:require-macros [datalog.parser.impl.util :refer [raise]]))
   (:refer-clojure :exclude [seqable?]))
 
 #?(:clj (set! *warn-on-reflection* true))

--- a/src/datalog/parser/pull.cljc
+++ b/src/datalog/parser/pull.cljc
@@ -1,7 +1,7 @@
 (ns datalog.parser.pull
   (:require [datalog.parser.impl.util :as util
              #?(:cljs :refer-macros :clj :refer) [raise forv]])
-  (:refer-clojure :rename {pos? core-pos?}))
+  (:refer-clojure :rename {pos? core-pos?} #?@(:cljs (:exclude (pos?)))))
 
 #?(:clj (set! *warn-on-reflection* true))
 


### PR DESCRIPTION
this adds a missing self require for raise macro + an exclusion form to silence a rename warning per [CLJS-2292](https://clojure.atlassian.net/browse/CLJS-2292)