### PR TITLE
Allow pull patterns that are sets

### DIFF
--- a/src/datalog/parser/pull.cljc
+++ b/src/datalog/parser/pull.cljc
@@ -190,7 +190,8 @@ legacy-limit-expr   = [(\"limit\" | 'limit') attr-name (positive-number | nil)]
 legacy-default-expr = [(\"default\" | 'default') attr-name any-value]
 ```"
   [pattern]
-  (when (sequential? pattern)
+  (when (or (sequential? pattern)
+            (set? pattern))
     (->> pattern
          simplify-pattern-clauses
          (mapv parse-attr-spec)

--- a/test/datalog/parser/pull_test.cljc
+++ b/test/datalog/parser/pull_test.cljc
@@ -12,6 +12,9 @@
   (testing "simple attribute"
     (is (= (dpp/->PullSpec false {:foo {:attr :foo}})
            (dpp/parse-pull '[:foo]))))
+  (testing "simple attribute in set"
+    (is (= (dpp/->PullSpec false {:foo {:attr :foo}})
+           (dpp/parse-pull '#{:foo}))))
   (testing "namespaced attribute"
     (is (= (dpp/->PullSpec false {:db/id   {:attr :db/id}
                                   :foo/bar {:attr :foo/bar}})
@@ -24,7 +27,9 @@
            (dpp/parse-pull '[(:foo :default "bar")]))))
   (testing "as"
     (is (= (dpp/->PullSpec false {:foo {:attr :foo :as "bar"}})
-           (dpp/parse-pull '[(:foo :as "bar")])))))
+           (dpp/parse-pull '[(:foo :as "bar")]))))
+  (testing "bad syntax"
+    (is (thrown? Throwable (dpp/parse-pull '{:foo 119})))))
 
 (deftest map-specs-test
   (testing "wildcard"


### PR DESCRIPTION
This makes it possible for a pull pattern to be a set, which is also possible in Datomic.